### PR TITLE
Fix config path in example Docker command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ path for other systems.
 
 ```sh
 $ docker build . -t opencred-platform
-$ docker run -d -p 22443:22443 -v $PWD/configs:/etc/app-config opencred-platform
+$ docker run -d -p 22443:22443 -v $PWD/configs:/etc/bedrock-config opencred-platform
 $ curl https://localhost:22443/health/live
 ```
 


### PR DESCRIPTION
I think the correct config path is `/etc/bedrock-config`?