### PR TITLE
feat: resolve did:key jwk_jcs-pub (multicodec 0xeb51) P-256 keys

### DIFF
--- a/common/documentLoader.js
+++ b/common/documentLoader.js
@@ -52,6 +52,7 @@ import {
 
 import {agent} from '@bedrock/https-agent';
 import {contextFetch} from '../lib/logger/events/contextFetch.js';
+import {decode as base58Decode} from 'base58-universal';
 import {httpClient} from '@digitalbazaar/http-client';
 import {logger} from '../lib/logger.js';
 
@@ -76,6 +77,80 @@ didKeyDriver.use({
   fromMultibase: EcdsaMultikey.from,
   multibaseMultikeyHeader: 'zDna'
 });
+// did:key jwk_jcs-pub (multicodec 0xeb51): EUDI Wallet / OpenID4VC P-256 keys
+// encoded as a JCS-normalized JWK. The base58 prefix shifts with the JWK length
+// (z2dm / z8DK / zYqN ...), so we route by the decoded multicodec rather than a
+// string prefix: any 0xeb51 did:key is parsed, its P-256 coordinates normalized
+// to 32 bytes, and canonicalized to the p256-pub (zDna) form, then resolved by
+// the existing driver. Other multicodecs fall through unchanged.
+const MULTICODEC_JWK_JCS_PUB = 0xeb51;
+
+// Read an unsigned LEB128 varint from the head of `bytes`.
+const readVarint = bytes => {
+  let value = 0;
+  let i = 0;
+  for(; i < bytes.length; i++) {
+    value += (bytes[i] & 0x7f) * (2 ** (7 * i));
+    if((bytes[i] & 0x80) === 0) {
+      return {value, length: i + 1};
+    }
+  }
+  return {value, length: i};
+};
+
+// Normalize a base64url-encoded P-256 coordinate to exactly 32 bytes. Some
+// issuers add a leading sign byte (BigInteger serialization) producing 33;
+// RFC 7518 mandates a fixed 32-byte length.
+const normalizeP256Coordinate = b64u => {
+  let bytes = Buffer.from(b64u, 'base64url');
+  if(bytes.length > 32) {
+    bytes = bytes.subarray(bytes.length - 32);
+  } else if(bytes.length < 32) {
+    const padded = Buffer.alloc(32);
+    bytes.copy(padded, 32 - bytes.length);
+    bytes = padded;
+  }
+  return bytes.toString('base64url');
+};
+
+// Convert a jwk_jcs-pub payload (JWK JSON bytes) to a canonical p256-pub
+// (`did:key:zDna…`) identifier, or null if it is not a P-256 EC key.
+const jwkJcsPubToP256DidKey = async jwkBytes => {
+  const jwk = JSON.parse(new TextDecoder().decode(jwkBytes));
+  if(jwk.kty !== 'EC' || jwk.crv !== 'P-256') {
+    return null;
+  }
+  jwk.x = normalizeP256Coordinate(jwk.x);
+  jwk.y = normalizeP256Coordinate(jwk.y);
+  const key = await EcdsaMultikey.fromJwk({jwk});
+  return `did:key:${key.publicKeyMultibase}`;
+};
+
+// Route did:key resolution by decoded multicodec (not multibase string prefix),
+// so every jwk_jcs-pub length variant (z2dm/z8DK/zYqN/…) resolves.
+const baseDidKeyGet = didKeyDriver.get.bind(didKeyDriver);
+didKeyDriver.get = async (options = {}) => {
+  const id = options.did || options.url;
+  if(typeof id === 'string' && id.startsWith('did:key:z')) {
+    const multibase = id.split('#')[0].slice('did:key:'.length);
+    let decoded = null;
+    try {
+      decoded = base58Decode(multibase.slice(1));
+    } catch {
+      decoded = null;
+    }
+    if(decoded && decoded.length) {
+      const {value: multicodec, length} = readVarint(decoded);
+      if(multicodec === MULTICODEC_JWK_JCS_PUB) {
+        const canonical = await jwkJcsPubToP256DidKey(decoded.slice(length));
+        if(canonical) {
+          return baseDidKeyGet({...options, did: canonical, url: undefined});
+        }
+      }
+    }
+  }
+  return baseDidKeyGet(options);
+};
 
 export const didResolver = new CachedResolver();
 didResolver.use(didKeyDriver);

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "@unhead/vue": "^2.1.15",
         "@vueuse/core": "^14.3.0",
         "autoprefixer": "^10.4.24",
+        "base58-universal": "^2.0.0",
         "base64url": "^3.0.1",
         "base64url-universal": "^2.0.0",
         "bnid": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "@unhead/vue": "^2.1.15",
     "@vueuse/core": "^14.3.0",
     "autoprefixer": "^10.4.24",
+    "base58-universal": "^2.0.0",
     "base64url": "^3.0.1",
     "base64url-universal": "^2.0.0",
     "bnid": "^3.0.0",

--- a/test/bedrock/40-documentLoader.test.js
+++ b/test/bedrock/40-documentLoader.test.js
@@ -7,6 +7,8 @@
 
 import * as obCtx from '@digitalcredentials/open-badges-context';
 import * as sinon from 'sinon';
+import {encode as base58Encode} from 'base58-universal';
+import {canonicalize} from 'json-canonicalize';
 import expect from 'expect.js';
 import {getDocumentLoader} from '../../common/documentLoader.js';
 import {httpClient} from '@digitalbazaar/http-client';
@@ -15,6 +17,28 @@ const documentLoader = getDocumentLoader().build();
 
 const exampleDidKeyId =
   'did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH';
+
+// Build a did:key z2dm (jwk_jcs-pub, multicodec 0xeb51 -> varint d1 d6 03)
+// identifier from a P-256 public JWK, mirroring how EUDI Wallet encodes the
+// `iss` of its credentials. This is the inverse of the decode path added in
+// common/documentLoader.js, so resolving it round-trips through fromJwk().
+const JWK_JCS_PUB_MULTICODEC_HEADER = [0xd1, 0xd6, 0x03];
+const encodeZ2dmDidKey = jwk => {
+  const jwkBytes = new TextEncoder().encode(canonicalize(jwk));
+  const bytes = new Uint8Array(
+    JWK_JCS_PUB_MULTICODEC_HEADER.length + jwkBytes.length);
+  bytes.set(JWK_JCS_PUB_MULTICODEC_HEADER, 0);
+  bytes.set(jwkBytes, JWK_JCS_PUB_MULTICODEC_HEADER.length);
+  return `did:key:z${base58Encode(bytes)}`;
+};
+
+// sample P-256 public JWK
+const exampleP256Jwk = {
+  crv: 'P-256',
+  kty: 'EC',
+  x: 'Di16iGSpSZ860BY4Igv_psd-y2R0tq4v4_vxVoUqPW0',
+  y: 'v6QvWfgBfSV1xOxHmVjTPyiAcfjTaufzt7tiP6XoF6U'
+};
 
 describe('Document Loader', async () => {
   it('load did:key document', async function() {
@@ -29,6 +53,54 @@ describe('Document Loader', async () => {
     expect(didKeyData.document).property('capabilityInvocation');
     expect(didKeyData.document).property('keyAgreement');
     expect(didKeyData.document.id).equal(didKeyData.documentUrl);
+  });
+
+  it('load did:key z2dm (jwk_jcs-pub P-256) document', async function() {
+    const z2dmDidKeyId = encodeZ2dmDidKey(exampleP256Jwk);
+    const didKeyData = await documentLoader(z2dmDidKeyId);
+    expect(didKeyData).property('document');
+    expect(didKeyData).property('documentUrl');
+    expect(didKeyData.document).property('id');
+    expect(didKeyData.document).property('verificationMethod');
+    expect(didKeyData.document).property('authentication');
+    expect(didKeyData.document).property('assertionMethod');
+    expect(didKeyData.document).property('capabilityDelegation');
+    expect(didKeyData.document).property('capabilityInvocation');
+    expect(didKeyData.document.id).equal(didKeyData.documentUrl);
+    // resolves to a P-256 verification method; the document id is the canonical
+    // p256-pub (zDna) form, since jwk_jcs-pub is normalized and routed there
+    expect(didKeyData.document.verificationMethod[0])
+      .property('publicKeyMultibase');
+  });
+
+  // z8DK / zYqN: same P-256 key, but a coordinate carries a leading sign byte
+  // (33 bytes), shifting the base58 prefix. Multicodec routing + coordinate
+  // normalization must resolve them to the same key as z2dm.
+  it('load did:key jwk_jcs-pub with 33-byte coordinates', async function() {
+    const pad33 = b64u => Buffer.concat(
+      [Buffer.from([0]), Buffer.from(b64u, 'base64url')]).toString('base64url');
+    const z2dm = encodeZ2dmDidKey(exampleP256Jwk);
+    const z8dk = encodeZ2dmDidKey({
+      ...exampleP256Jwk, y: pad33(exampleP256Jwk.y)});
+    const zyqn = encodeZ2dmDidKey({
+      ...exampleP256Jwk,
+      x: pad33(exampleP256Jwk.x),
+      y: pad33(exampleP256Jwk.y)
+    });
+    // the three encodings really do have different multibase prefixes
+    expect(z8dk.slice(0, 12)).not.equal(z2dm.slice(0, 12));
+    expect(zyqn.slice(0, 12)).not.equal(z2dm.slice(0, 12));
+    const ids = [];
+    for(const did of [z2dm, z8dk, zyqn]) {
+      const data = await documentLoader(did);
+      expect(data.document).property('verificationMethod');
+      expect(data.document.verificationMethod[0])
+        .property('publicKeyMultibase');
+      ids.push(data.document.id);
+    }
+    // all variants normalize to the same canonical key / document id
+    expect(ids[0]).equal(ids[1]);
+    expect(ids[1]).equal(ids[2]);
   });
 
   it('load did:jwk document', async function() {


### PR DESCRIPTION
## Resolve `did:key` `jwk_jcs-pub` (multicodec `0xeb51`) P-256 keys

### Summary

Adds support for resolving `did:key` identifiers that encode a P-256 public
key as a JCS-normalized JWK (multicodec `0xeb51`, `jwk_jcs-pub`). These keys are
how EUDI Wallet / OpenID4VC issuers commonly represent their signing keys, and
OpenCred currently fails to resolve them, so credentials issued by such wallets
cannot be verified.

### Motivation

OpenCred's `did:key` driver is registered only for the `p256-pub` multicodec
(`zDna…` multibase prefix). EUDI Wallet / OpenID4VC issuers instead publish
their P-256 keys using the `jwk_jcs-pub` multicodec (`0xeb51`), whose base58btc
multibase prefix is **not fixed** — it shifts with the encoded JWK length
(`z2dm…`, `z8DK…`, `zYqN…`, …). As a result:

- The keys are unresolvable today, and any VC whose `iss` is such a `did:key`
  fails signature verification with a resolver error.
- Routing by the multibase **string prefix** is unreliable, because the same
  logical key can surface under several different prefixes.

### Approach

Route `did:key` resolution by the **decoded multicodec** rather than the
multibase string prefix:

1. Decode the multibase (base58btc) payload and read its leading multicodec
   varint (LEB128).
2. If the multicodec is `0xeb51` (`jwk_jcs-pub`), parse the embedded JWK; if it
   is an `EC` / `P-256` key, normalize the `x`/`y` coordinates to exactly 32
   bytes (per RFC 7518 §6.2.1.2 — some issuers serialize a coordinate with a
   leading sign byte, yielding 33 bytes) and re-derive the canonical `p256-pub`
   (`zDna…`) `did:key` via `EcdsaMultikey.fromJwk`.
3. Delegate to the **existing** driver with that canonical identifier.

Any other multicodec (including today's `zDna…` keys) falls through to the
existing driver completely unchanged. The change is a thin wrapper around
`didKeyDriver.get`, so it adds a new key *family* without altering resolution
of currently-supported keys.

### Backward compatibility

Fully backward compatible. Non-`0xeb51` `did:key` identifiers take the original
code path with no behavioral change; only previously-unresolvable
`jwk_jcs-pub` keys are newly handled.

### Dependencies

Promotes `base58-universal` (already present transitively) to a direct
dependency, used to decode the multibase payload for multicodec inspection.

### Testing

Adds `test/bedrock/40-documentLoader.test.js` coverage that builds `jwk_jcs-pub`
`did:key` identifiers from a sample P-256 JWK and resolves them through the
document loader:

- Resolves a `z2dm…` (`jwk_jcs-pub`) identifier to a P-256 verification method
  whose document id is the canonical `p256-pub` (`zDna…`) form.
- Resolves the `z8DK…` / `zYqN…` variants (same key, but with 33-byte
  coordinates that shift the multibase prefix) and asserts all three normalize
  to the **same** canonical key / document id — exercising both the
  multicodec routing and the coordinate normalization.