### PR TITLE
fix: treat vc.issuer as optional per W3C VC-JWT encoding

### DIFF
--- a/common/audit.js
+++ b/common/audit.js
@@ -49,7 +49,18 @@ const _getVpTokenMetadataJwt = vpToken => {
       const issuerDidJwt = vcJwtPayload?.iss;
       const issuerDidVc = typeof vcJwtPayload?.vc?.issuer === 'string' ?
         vcJwtPayload.vc.issuer : vcJwtPayload?.vc?.issuer?.id;
-      if(!issuerDidJwt || !issuerDidVc || issuerDidJwt !== issuerDidVc) {
+      // Per the W3C VC Data Model JWT encoding, the `iss` claim represents the
+      // issuer and `vc.issuer` MAY be omitted. Treat `iss` as authoritative;
+      // only fail when `iss` is absent, or when `vc.issuer` is present and
+      // disagrees with `iss`.
+      if(!issuerDidJwt) {
+        return {
+          valid: false,
+          error: 'Each vc token must have an issuer (JWT "iss")',
+          issuerDids
+        };
+      }
+      if(issuerDidVc && issuerDidVc !== issuerDidJwt) {
         return {
           valid: false,
           error: 'Each vc token issuer must match the issuer ' +

--- a/test/unit/15-audit-vc-issuer.test.js
+++ b/test/unit/15-audit-vc-issuer.test.js
@@ -1,0 +1,56 @@
+/*!
+ * Copyright 2023 - 2026 California Department of Motor Vehicles
+ * Copyright 2023 - 2026 Digital Bazaar, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {getVpTokenMetadata} from '../../common/audit.js';
+import expect from 'expect.js';
+
+// Encode a payload as an (unsigned) JWT. getVpTokenMetadata uses decodeJwt,
+// which does not verify the signature, so a placeholder signature suffices.
+const b64u = obj => Buffer.from(JSON.stringify(obj)).toString('base64url');
+const jwt = payload => `${b64u({alg: 'ES256', typ: 'JWT'})}.${b64u(payload)}.AAAA`;
+// Build a VP-JWT whose `vp.verifiableCredential` holds the given VC payloads,
+// each itself encoded as a VC-JWT.
+const vpToken = vcPayloads =>
+  jwt({vp: {verifiableCredential: vcPayloads.map(jwt)}});
+
+const ISS = 'did:key:zDnaeyXNn6Xc8KZ9Yx1vJhRYV7Vvac7vZxbzb1234567890ab';
+const OTHER = 'did:key:zDnaOtherIssuer000000000000000000000000000000000';
+
+describe('getVpTokenMetadata - vc.issuer per W3C VC-JWT encoding', () => {
+  it('accepts a VC-JWT that omits vc.issuer (iss is authoritative)', () => {
+    const res = getVpTokenMetadata(
+      vpToken([{iss: ISS, vc: {type: ['VerifiableCredential']}}]));
+    expect(res.valid).to.be(true);
+    expect(res.issuerDids).to.eql([ISS]);
+  });
+
+  it('accepts when vc.issuer (string) matches iss', () => {
+    const res = getVpTokenMetadata(
+      vpToken([{iss: ISS, vc: {issuer: ISS}}]));
+    expect(res.valid).to.be(true);
+    expect(res.issuerDids).to.eql([ISS]);
+  });
+
+  it('accepts when vc.issuer object id matches iss', () => {
+    const res = getVpTokenMetadata(
+      vpToken([{iss: ISS, vc: {issuer: {id: ISS}}}]));
+    expect(res.valid).to.be(true);
+    expect(res.issuerDids).to.eql([ISS]);
+  });
+
+  it('rejects when a present vc.issuer disagrees with iss', () => {
+    const res = getVpTokenMetadata(
+      vpToken([{iss: ISS, vc: {issuer: OTHER}}]));
+    expect(res.valid).to.be(false);
+  });
+
+  it('rejects when iss is absent', () => {
+    const res = getVpTokenMetadata(
+      vpToken([{vc: {type: ['VerifiableCredential']}}]));
+    expect(res.valid).to.be(false);
+  });
+});


### PR DESCRIPTION
## Treat `vc.issuer` as optional per the W3C VC Data Model JWT encoding

### Summary

When extracting issuer metadata from a VP token, OpenCred currently requires the
inner VC-JWT to carry a `vc.issuer` property and rejects the token if it is
absent. Under the W3C VC Data Model **JWT encoding**, the JWT `iss` claim
represents the issuer and `vc.issuer` MAY be omitted. This change treats `iss`
as authoritative so conformant VC-JWTs that omit `vc.issuer` are no longer
wrongly rejected.

### Motivation

In `common/audit.js`, `_getVpTokenMetadataJwt` derived two issuer values per
inner credential — `iss` (the JWT claim) and `vc.issuer` (the embedded VC
property) — and failed unless **both** were present and equal:

```js
if(!issuerDidJwt || !issuerDidVc || issuerDidJwt !== issuerDidVc) { /* reject */ }
```

Per the [W3C VC Data Model — JWT encoding](https://www.w3.org/TR/vc-data-model/#jwt-encoding),
when a credential is encoded as a JWT the `iss` claim is the authoritative
issuer and the `issuer` property inside the `vc` object MAY be dropped (its
value is recoverable from `iss`). EUDI Wallet / OpenID4VC issuers commonly emit
such VC-JWTs. Against these, the old check rejected a perfectly conformant
credential with *"Each vc token issuer must match the issuer…"*, even though
`iss` was present and the signature valid.

### Approach

Treat the JWT `iss` claim as the source of truth:

- Fail if `iss` is **absent** (a VC-JWT must have an issuer).
- If `vc.issuer` is **present**, it must agree with `iss` (guards against an
  inconsistent embedded value).
- If `vc.issuer` is **omitted**, accept and use `iss`.

`iss` is covered by the JWT signature, so authority is unchanged — this only
stops rejecting the spec-permitted "omitted `vc.issuer`" shape. No issuer
binding is weakened: a present-but-mismatched `vc.issuer` is still rejected.

### Backward compatibility

Fully backward compatible. VC-JWTs that include a matching `vc.issuer`
(the previously-required shape) behave exactly as before; only the
spec-conformant omitted/`iss`-authoritative case is newly accepted. A present
`vc.issuer` that disagrees with `iss` is still rejected.

### Testing

Adds `test/unit/15-audit-vc-issuer.test.js`, covering issuer extraction from a
VP-JWT for each case:

- `vc.issuer` omitted → accepted, `iss` used as the issuer.
- `vc.issuer` present and matching `iss` → accepted (both string and `{id}`
  object forms).
- `vc.issuer` present but disagreeing with `iss` → rejected.
- `iss` absent → rejected.

Also verified end-to-end against EUDI-Wallet-issued VC-JWTs that omit
`vc.issuer`: metadata extraction now succeeds where it previously failed.