### PR TITLE
fix: resolve path_nested against the $.vp root for jwt_vp_json

### DIFF
--- a/lib/workflows/common/oid4vp-shared.js
+++ b/lib/workflows/common/oid4vp-shared.js
@@ -83,6 +83,14 @@ export async function verifyJwtSubmission({
       vc = vcQuery(vpResult.verifiablePresentation);
     }
 
+    // Some wallets root path_nested at the decoded VP-JWT, i.e.
+    // `$.vp.verifiableCredential[...]` (the standard jwt_vp_json path).
+    // unenvelopeJwtVp() strips the `.vp` wrapper, so also try a `{vp}`-wrapped
+    // structure.
+    if(!vc && vcQuery) {
+      vc = vcQuery({vp});
+    }
+
     // Handle JWT string VCs (from vpResult.verifiablePresentation)
     const vcJwt = typeof vc === 'string' ? vc : (vc?.proof?.jwt);
 

--- a/test/unit/workflows/16-path-nested-vp.test.js
+++ b/test/unit/workflows/16-path-nested-vp.test.js
@@ -1,0 +1,32 @@
+/*!
+ * Copyright 2023 - 2026 California Department of Motor Vehicles
+ * Copyright 2023 - 2026 Digital Bazaar, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {JSONPath} from 'jsonpath-plus';
+import expect from 'expect.js';
+
+// Mirrors the production vcQuery built from `presentation_submission`
+// `path_nested.path` in verifyOID4VPSubmission / verifyDraft18Submission
+// (lib/workflows/common/oid4vp-shared.js). Wallets conventionally root the
+// jwt_vp_json path_nested at the decoded VP-JWT (`$.vp.verifiableCredential`).
+const vcQuery = vp =>
+  JSONPath({path: '$.vp.verifiableCredential[0]', json: vp})[0];
+
+describe('jwt_vp_json path_nested rooted at $.vp', () => {
+  // unenvelopeJwtVp() strips the `.vp` wrapper, leaving the inner presentation
+  // object directly (no `.vp`), which is what verifyJwtSubmission applies
+  // vcQuery to first.
+  const unwrappedVp = {verifiableCredential: ['vc-jwt-string']};
+
+  it('a $.vp-rooted path does not resolve against the unwrapped VP', () => {
+    // Without the `{vp}` fallback this yields "VC not found in presentation".
+    expect(vcQuery(unwrappedVp)).to.be(undefined);
+  });
+
+  it('resolves once the VP is re-wrapped as {vp} (the fix)', () => {
+    expect(vcQuery({vp: unwrappedVp})).to.be('vc-jwt-string');
+  });
+});


### PR DESCRIPTION
## Resolve `path_nested` against the `$.vp` root for `jwt_vp_json`

### Summary

For `jwt_vp_json` presentations, wallets conventionally set the
`presentation_submission` `path_nested` to `$.vp.verifiableCredential[...]`
— rooted at the decoded VP-JWT, which carries a `vp` claim. OpenCred strips the
`vp` wrapper before applying that path, so the standard path resolves to
nothing and verification fails with *"VC not found in presentation."* This adds
a `{vp}`-wrapped fallback so both the wrapped and unwrapped paths resolve.

### Motivation

In `verifyJwtSubmission` (`lib/workflows/common/oid4vp-shared.js`), the VP-JWT is
decoded via `unenvelopeJwtVp(vp_token)`, which **strips the `.vp` wrapper** and
returns the inner presentation object. The `path_nested` selector (`vcQuery`)
is then applied to that unwrapped object.

However, per the OpenID4VP / Presentation Exchange convention for
`jwt_vp_json`, wallets express `path_nested` relative to the **decoded VP-JWT**,
whose payload has the form `{ "vp": { "verifiableCredential": [...] } }`. So a
conformant wallet sends:

```json
{ "path_nested": { "path": "$.vp.verifiableCredential[0]", ... } }
```

Applied to the already-unwrapped object, `$.vp.verifiableCredential[0]`
matches nothing → the credential is never located → verification fails even
though the presentation and credential are valid. This blocks interop with
wallets (e.g. EUDI Wallet) that use the standard `$.vp`-rooted path.

### Approach

After the existing lookups fail to locate the VC, try the selector against a
`{vp}`-re-wrapped structure:

```js
if(!vc && vcQuery) {
  vc = vcQuery({vp});
}
```

This makes both forms resolve:

- `$.verifiableCredential[...]` (against the unwrapped object — existing path)
- `$.vp.verifiableCredential[...]` (against the `{vp}`-wrapped object — standard)

The fallback runs **only** when the prior lookups returned nothing; the located
VC still goes through full VC-JWT signature verification and the
`trustedCredentialIssuers` check downstream, so no verification step is skipped.

### Backward compatibility

Fully backward compatible. The new branch is a fallback reached only when the
existing selectors return no VC; submissions that resolve today are unaffected.

### Testing

Adds `test/unit/workflows/16-path-nested-vp.test.js`, asserting that a
production-shaped `vcQuery` (built from a `$.vp.verifiableCredential[...]`
`path_nested`) does **not** resolve against the unwrapped VP but **does**
resolve once the VP is re-wrapped as `{vp}` — i.e. the fallback this change
adds.

Also verified end-to-end with a wallet that sets `path_nested` to
`$.vp.verifiableCredential[...]`: the credential is now located and verified,
where it previously failed with "VC not found in presentation."