### PR TITLE
docs: document EUDI Wallet / TWDIW config in combined.example.yaml

### DIFF
--- a/configs/combined.example.yaml
+++ b/configs/combined.example.yaml
@@ -275,6 +275,32 @@ app:
           - did:jwk:eyJjcnYiOiJQLTI1NiIsImt0eSI6IkVDIiwieCI6ImJSbGpTekVyS0lfQk5OME1LRVBIVVdHcVR1Um5fVm42eXJvQlRfR0RDbFUiLCJ4NWMiOlsiTUlJQ2VUQ0NBaCtnQXdJQkFnSVVOYjF2czlucklGTmt4Vy9BaDVSYnFTazVENXN3Q2dZSUtvWkl6ajBFQXdJd1VURUxNQWtHQTFVRUJoTUNWVk14RGpBTUJnTlZCQWdNQlZWVExVTkJNUTh3RFFZRFZRUUtEQVpEUVMxRVRWWXhJVEFmQmdOVkJBTU1HRU5oYkdsbWIzSnVhV0VnUkUxV0lFbEJRMEVnVW05dmREQWVGdzB5TmpBME1UQXhOVE14TWpGYUZ3MHlOekEzTURreE5UTXhNakZhTUZZeEN6QUpCZ05WQkFZVEFsVlRNUTR3REFZRFZRUUlEQVZWVXkxRFFURVBNQTBHQTFVRUNnd0dRMEV0UkUxV01TWXdKQVlEVlFRRERCMURZV3hwWm05eWJtbGhJRVJOVmlCSlFVTkJJRlpESUZOcFoyNWxjakJaTUJNR0J5cUdTTTQ5QWdFR0NDcUdTTTQ5QXdFSEEwSUFCRzBaWTBzeEt5aVB3VFRkRENoRHgxRmhxazdrWi8xWitzcTZBVS94Z3dwVkp5T0k4cVNYRHl6NFpPQTJtR21sSnlrUGtjdnRTRjRjUnJNQlhDRDRIVitqZ2M4d2djd3dIUVlEVlIwT0JCWUVGREdQUUxGRUhwaWp2b0ZYaUNpV2c1Z2VVeGpZTUI4R0ExVWRJd1FZTUJhQUZMdDlkV2VTZW0vUG4zSjd1QXIzTnkrY0RGQTJNQjBHQ1dDR1NBR0crRUlCRFFRUUZnNURZV3hwWm05eWJtbGhJRVJOVmpBT0JnTlZIUThCQWY4RUJBTUNCNEF3SVFZRFZSMFNCQm93R0lFV2FXRmpZUzF6YVdkdVpYSkFaRzEyTG1OaExtZHZkakE0QmdOVkhSOEVNVEF2TUMyZ0s2QXBoaWRvZEhSd2N6b3ZMMk55YkM1a2JYWXVZMkV1WjI5MkwybGhZMkV2YldSdll5MXphV2R1WlhJd0NnWUlLb1pJemowRUF3SURTQUF3UlFJZ01yaGlFQ005ZU1JeHRRTzFmK1daUFhuaGRxK0g0ZWlPcnA4a0xpUkFkc0VDSVFDZDI4MktSUEsyUTVtdkRPUGMrRGVrYzFhR3RaRnRhaHVreS9NeDZWQ2JsZz09Il0sInkiOiJKeU9JOHFTWER5ejRaT0EybUdtbEp5a1BrY3Z0U0Y0Y1JyTUJYQ0Q0SFY4In0
           - did:web:example.com
         public: true
+      - name: "EUDI Wallet / TWDIW VC"
+        # Verifies a VC-JWT issued by an EUDI-Wallet / TWDIW-style issuer and
+        # presented over OpenID4VP. The issuer key is a did:key encoded as a
+        # JCS-normalized JWK (jwk_jcs-pub, multicodec 0xeb51; the multibase
+        # prefix shifts with the JWK length: z2dm/z8DK/zYqN...) and is resolved
+        # automatically. The VC-JWT issuer is the JWT `iss` claim (`vc.issuer`
+        # may be omitted), and the wallet's $.vp-rooted presentation_submission
+        # path_nested is handled automatically.
+        clientId: "eudi-vc"
+        clientSecret: "<set-a-strong-secret>"
+        type: native
+        query:
+          - type:
+              - "<your-credential-type>"
+            format:
+              - jwt_vc_json
+        trustedCredentialIssuers:
+          # did:key issuers are self-certifying: a valid signature only proves
+          # "this key signed it". Without an allowlist ANY did:key issuer is
+          # accepted, so pin the issuer DID(s) the wallet puts in the VC-JWT
+          # `iss` claim (a jwk_jcs-pub did:key, e.g. z2dm...).
+          - "did:key:z2dm...<issuer-public-key>"
+        # Revocation: if the credential carries a StatusList2021Entry and its
+        # issuer is trusted, OpenCred verifies the status list automatically;
+        # no extra workflow configuration is required.
+        public: true
     options:
       exchangeProtocols:
         - chapi
@@ -283,6 +309,11 @@ app:
       #                        # profile is enabled by default. Can be
       #                        # overridden per-workflow. Default: true.
       recordExpiresDurationMs: 86400000
+      # OID4VPdefault: the OID4VP profile used to build the QR / wallet launch
+      # URL and request object. EUDI Wallet / TWDIW wallets consume a
+      # presentation_definition (OID4VP draft 18) rather than DCQL; set
+      # "OID4VP-draft18" for those wallets. Default: "OID4VP-combined".
+      # OID4VPdefault: "OID4VP-draft18"
     defaultBrand:
       cta: "#0B669D"
       primary: "#045199"


### PR DESCRIPTION
## Document EUDI Wallet / TWDIW configuration in `combined.example.yaml`

### Summary

Adds a worked, sanitized example to `configs/combined.example.yaml` showing how
to configure a workflow that verifies EUDI-Wallet / TWDIW-style credentials over
OpenID4VP, plus an inline `OID4VPdefault` example. Documentation only — no code
changes.

### Motivation

OpenCred can verify EUDI-Wallet / TWDIW credentials, but the configuration that
ties the pieces together is not shown anywhere in the example config. A
deployer setting this up needs to know:

- which OID4VP profile these wallets expect (`OID4VP-draft18`, a
  `presentation_definition` rather than DCQL);
- that `did:key` issuers must be pinned via `trustedCredentialIssuers`, and that
  the issuer DID is a `jwk_jcs-pub` key (`z2dm/z8DK/zYqN...`) matching the
  VC-JWT `iss`;
- that the `jwk_jcs-pub` resolution, optional `vc.issuer`, and `$.vp`-rooted
  `path_nested` are all handled automatically.

### Approach

- Add a new commented example workflow (`EUDI Wallet / TWDIW VC`) alongside the
  existing example workflows, using placeholder values (`<set-a-strong-secret>`,
  `<your-credential-type>`, `did:key:z2dm...<issuer-public-key>`) — no secrets.
- Add a commented `OID4VPdefault: "OID4VP-draft18"` example under `options`,
  matching the file's existing "commented optional setting" style.

The example is kept **inline in the single canonical example file** rather than
a separate doc/example file, so there is one source of truth and it is
discoverable next to every other option. Non-standard specifics (the
`StatusList2021Entry` envelope) are noted in a single line only, not expanded
here.

### Backward compatibility

Documentation only; `combined.example.yaml` is a template and is not loaded at
runtime. No behavioral change.

### Testing

N/A (comments / example config only). The YAML was validated to parse.

### Depends on

This example documents behavior introduced by the related PRs:

- did:key `jwk_jcs-pub` resolution
- `vc.issuer` optional (W3C VC-JWT encoding)
- `path_nested` `$.vp` resolution
- `StatusList2021Entry` status (optional)

Recommend merging after those, or treat this as documentation that lands once
the corresponding features are present.